### PR TITLE
Click on the status bar item to restart RLS

### DIFF
--- a/doc/rls_mode/main.md
+++ b/doc/rls_mode/main.md
@@ -132,9 +132,9 @@ When the extension functions in RLS mode, an indicator is displayed in the statu
 
 The indicator may show one of the following statuses:
 
-* `Starting` - RLS is starting, hence no features are available
-* `Analysis started` - RLS has begun analyzing code. Features are available, but result may be inaccurate
-* `Analysis finished` - RLS has finished analyzing code. Features are available and result should be exact
+* `Starting` - RLS is starting, hence no features of the extension are available
+* `Analysis started` - RLS has begun analyzing code. Features are available, but the analysis is incomplete therefore possibly inaccurate
+* `Analysis finished` - RLS has finished analyzing code. Features are available and the analysis should be accurate
 * `Stopping` - RLS has been requested to stop. Features may or may not be available
 * `Stopped` - RLS has been stopped. Features are unavailable
 

--- a/doc/rls_mode/main.md
+++ b/doc/rls_mode/main.md
@@ -128,16 +128,14 @@ For making RLS print more data, you have to add the following lines to your `"ru
 
 ## Status Bar Indicator
 
-When the extension functions in this mode, the indicator shows in the status bar.
-
-The indicator shows the current status of RLS.
+When the extension functions in RLS mode, an indicator is displayed in the status bar that shows the current status of RLS.
 
 The indicator may show one of the following statuses:
 
 * `Starting` - RLS is starting, hence no features are available
-* `Analysis started` - RLS analyses code. Features are available, but result may be inaccurate
-* `Analysis finished` - RLS finished analysing code. Features are available and result should be exact
-* `Stopping` - RLS has been requested to stop. It started stopping. Features may or may not be available
+* `Analysis started` - RLS has begun analyzing code. Features are available, but result may be inaccurate
+* `Analysis finished` - RLS has finished analyzing code. Features are available and result should be exact
+* `Stopping` - RLS has been requested to stop. Features may or may not be available
 * `Stopped` - RLS has been stopped. Features are unavailable
 
 Clicking on the indicator restarts RLS.

--- a/doc/rls_mode/main.md
+++ b/doc/rls_mode/main.md
@@ -125,3 +125,19 @@ For making RLS print more data, you have to add the following lines to your `"ru
     }
 }
 ```
+
+## Status Bar Indicator
+
+When the extension functions in this mode, the indicator shows in the status bar.
+
+The indicator shows the current status of RLS.
+
+The indicator may show one of the following statuses:
+
+* `Starting` - RLS is starting, hence no features are available
+* `Analysis started` - RLS analyses code. Features are available, but result may be inaccurate
+* `Analysis finished` - RLS finished analysing code. Features are available and result should be exact
+* `Stopping` - RLS has been requested to stop. It started stopping. Features may or may not be available
+* `Stopped` - RLS has been stopped. Features are unavailable
+
+Clicking on the indicator restarts RLS.

--- a/src/components/language_client/manager.ts
+++ b/src/components/language_client/manager.ts
@@ -44,26 +44,38 @@ export class Manager {
         }));
     }
 
-    public start(): void {
+    /**
+     * Starts the language client at first time
+     */
+    public initialStart(): void {
+        this.start();
+
+        this.statusBarItem.show();
+    }
+
+    private start(): void {
         this.logger.debug('start');
 
         this.languageClient.start();
 
-        this.statusBarItem.updateVisibility();
-
+        // As we started the language client, we need to enable the indicator in order to allow the user restart the language client.
+        this.statusBarItem.setText('Starting');
         this.statusBarItem.enable();
     }
 
-    public async stop(): Promise<void> {
+    private async stop(): Promise<void> {
         this.logger.debug('stop');
 
         this.statusBarItem.disable();
+        this.statusBarItem.setText('Stopping');
 
         if (this.languageClient.needsStop()) {
             await this.languageClient.stop();
         }
 
         this.languageClient.outputChannel.dispose();
+
+        this.statusBarItem.setText('Stopped');
     }
 
     /** Stops the running language client if any and starts a new one. */
@@ -95,8 +107,6 @@ export class Manager {
                 this.languageClient.onNotification({ method: 'rustDocument/diagnosticsEnd' }, () => {
                     this.statusBarItem.setText('Analysis finished');
                 });
-            } else {
-                this.statusBarItem.setText('Stopped');
             }
         });
     }

--- a/src/components/language_client/manager.ts
+++ b/src/components/language_client/manager.ts
@@ -1,4 +1,4 @@
-import { ExtensionContext } from 'vscode';
+import { Disposable, ExtensionContext, window, workspace } from 'vscode';
 
 import { LanguageClient, State } from 'vscode-languageclient';
 
@@ -15,8 +15,6 @@ export class Manager {
 
     private statusBarItem: StatusBarItem;
 
-    private context: ExtensionContext;
-
     private logger: ChildLogger;
 
     public constructor(
@@ -28,22 +26,67 @@ export class Manager {
     ) {
         this.languageClientCreator = new LanguageClientCreator(executable, args, env);
 
-        this.context = context;
+        this.languageClient = this.languageClientCreator.create();
 
         this.statusBarItem = new StatusBarItem(context);
 
+        this.statusBarItem.setOnClicked(() => {
+            this.restart();
+        });
+
         this.logger = logger;
 
-        this.languageClient = this.languageClientCreator.create();
+        this.subscribeOnStateChanging();
+
+        context.subscriptions.push(new Disposable(() => {
+            this.stop();
+        }));
     }
 
     public start(): void {
         this.logger.debug('start');
 
-        this.languageClient.outputChannel.show();
+        this.languageClient.start();
 
+        this.statusBarItem.updateVisibility();
+
+        this.statusBarItem.enable();
+    }
+
+    public stop(): void {
+        this.logger.debug('stop');
+
+        this.statusBarItem.disable();
+
+        if (this.languageClient.needsStop()) {
+            this.languageClient.stop();
+        }
+    }
+
+    /** Stops the running language client if any and starts a new one. */
+    private restart(): void {
+        const isAnyDocumentDirty = !workspace.textDocuments.every(t => !t.isDirty);
+
+        if (isAnyDocumentDirty) {
+            window.showErrorMessage('You have unsaved changes. Save or discard them and try to restart again');
+
+            return;
+        }
+
+        this.stop();
+
+        this.languageClient = this.languageClientCreator.create();
+
+        this.subscribeOnStateChanging();
+
+        this.start();
+    }
+
+    private subscribeOnStateChanging(): void {
         this.languageClient.onDidChangeState(event => {
             if (event.newState === State.Running) {
+                this.languageClient.outputChannel.show();
+
                 this.languageClient.onNotification('rustDocument/diagnosticsBegin', () => {
                     this.statusBarItem.setText('Analysis started');
                 });
@@ -51,11 +94,9 @@ export class Manager {
                 this.languageClient.onNotification('rustDocument/diagnosticsEnd', () => {
                     this.statusBarItem.setText('Analysis finished');
                 });
+            } else {
+                this.statusBarItem.setText('Stopped');
             }
         });
-
-        this.context.subscriptions.push(this.languageClient.start());
-
-        this.statusBarItem.updateVisibility();
     }
 }

--- a/src/components/language_client/manager.ts
+++ b/src/components/language_client/manager.ts
@@ -54,18 +54,20 @@ export class Manager {
         this.statusBarItem.enable();
     }
 
-    public stop(): void {
+    public async stop(): Promise<void> {
         this.logger.debug('stop');
 
         this.statusBarItem.disable();
 
         if (this.languageClient.needsStop()) {
-            this.languageClient.stop();
+            await this.languageClient.stop();
         }
+
+        this.languageClient.outputChannel.dispose();
     }
 
     /** Stops the running language client if any and starts a new one. */
-    private restart(): void {
+    private async restart(): Promise<void> {
         const isAnyDocumentDirty = !workspace.textDocuments.every(t => !t.isDirty);
 
         if (isAnyDocumentDirty) {
@@ -74,7 +76,7 @@ export class Manager {
             return;
         }
 
-        this.stop();
+        await this.stop();
 
         this.languageClient = this.languageClientCreator.create();
 

--- a/src/components/language_client/status_bar_item.ts
+++ b/src/components/language_client/status_bar_item.ts
@@ -1,8 +1,6 @@
 import * as vscode from 'vscode';
 
-import { ExtensionContext, commands, languages, window } from 'vscode';
-
-import getDocumentFilter from '../configuration/mod';
+import { ExtensionContext, commands, window } from 'vscode';
 
 const command = 'rust.LanguageClient.StatusBarItem.Clicked';
 
@@ -12,7 +10,6 @@ export class StatusBarItem {
 
     public constructor(context: ExtensionContext) {
         this.statusBarItem = window.createStatusBarItem();
-        this.statusBarItem.tooltip = 'Click to restart';
 
         context.subscriptions.push(
             commands.registerCommand(command, () => {
@@ -21,15 +18,11 @@ export class StatusBarItem {
                 }
             })
         );
-
-        context.subscriptions.push(
-            window.onDidChangeActiveTextEditor(() => {
-                this.updateVisibility();
-            })
-        );
     }
 
-    /** Disables clicking on the status bar item */
+    /**
+     * Disallows the user to click on the indicator
+     */
     public disable(): void {
         // There is an error in the definition of StatusBarItem.command.
         // The expected type is `string | undefined`, but actual is `string`.
@@ -37,32 +30,38 @@ export class StatusBarItem {
         let statusBarItem: any = this.statusBarItem;
         // Disable clicking.
         statusBarItem.command = undefined;
+        // Remove tooltip because we don't want to say the user that we may click on the indicator which is disabled
+        statusBarItem.tooltip = undefined;
     }
 
-    /** Enables clicking on the status bar item */
+    /**
+     * Allows the user to click on the indicator
+     */
     public enable(): void {
         this.statusBarItem.command = command;
+        this.statusBarItem.tooltip = 'Click to restart';
     }
 
-    public setOnClicked(onClicked?: () => void): void {
+    /**
+     * Saves the specified closure as a closure which is invoked when the user clicks on the indicator
+     * @param onClicked closure to be invoked
+     */
+    public setOnClicked(onClicked: () => void | undefined): void {
         this.onClicked = onClicked;
     }
 
+    /**
+     * Makes the indicator show the specified text in the format "RLS: ${text}"
+     * @param text the text to be shown
+     */
     public setText(text: string): void {
         this.statusBarItem.text = `RLS: ${text}`;
     }
 
-    public updateVisibility(): void {
-        if (!window.activeTextEditor) {
-            this.statusBarItem.hide();
-
-            return;
-        }
-
-        if (languages.match(getDocumentFilter(), window.activeTextEditor.document)) {
-            this.statusBarItem.show();
-        } else {
-            this.statusBarItem.hide();
-        }
+    /**
+     * Shows the indicator in the status bar
+     */
+    public show(): void {
+        this.statusBarItem.show();
     }
 }

--- a/src/components/language_client/status_bar_item.ts
+++ b/src/components/language_client/status_bar_item.ts
@@ -1,20 +1,51 @@
 import * as vscode from 'vscode';
 
-import { ExtensionContext, languages, window } from 'vscode';
+import { ExtensionContext, commands, languages, window } from 'vscode';
 
 import getDocumentFilter from '../configuration/mod';
 
+const command = 'rust.LanguageClient.StatusBarItem.Clicked';
+
 export class StatusBarItem {
     private statusBarItem: vscode.StatusBarItem;
+    private onClicked?: () => void;
 
     public constructor(context: ExtensionContext) {
         this.statusBarItem = window.createStatusBarItem();
+        this.statusBarItem.tooltip = 'Click to restart';
+
+        context.subscriptions.push(
+            commands.registerCommand(command, () => {
+                if (this.onClicked !== undefined) {
+                    this.onClicked();
+                }
+            })
+        );
 
         context.subscriptions.push(
             window.onDidChangeActiveTextEditor(() => {
                 this.updateVisibility();
             })
         );
+    }
+
+    /** Disables clicking on the status bar item */
+    public disable(): void {
+        // There is an error in the definition of StatusBarItem.command.
+        // The expected type is `string | undefined`, but actual is `string`.
+        // This is workaround.
+        let statusBarItem: any = this.statusBarItem;
+        // Disable clicking.
+        statusBarItem.command = undefined;
+    }
+
+    /** Enables clicking on the status bar item */
+    public enable(): void {
+        this.statusBarItem.command = command;
+    }
+
+    public setOnClicked(onClicked?: () => void): void {
+        this.onClicked = onClicked;
     }
 
     public setText(text: string): void {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,7 +52,7 @@ export async function activate(ctx: ExtensionContext): Promise<void> {
             revealOutputChannelOn
         );
 
-        languageClientManager.start();
+        languageClientManager.initialStart();
     } else {
         const legacyModeManager = new LegacyModeManager(
             ctx,


### PR DESCRIPTION
This PR makes the status bar item indicating RLS status be clickable.
Clicking on the status bar item makes the extension restart RLS.
I checked it and it worked.
I'll try it again when I get home.

Motivation for the feature is that RLS is unstable, it may panic, it may crash.
Having a way to restart RLS is good feature.

Unresolved:

* Add information about the feature to the documentation