### PR TITLE
Support range formatting in legacy mode

### DIFF
--- a/doc/format.md
+++ b/doc/format.md
@@ -9,6 +9,7 @@ If the extension is running in [Legacy Mode](legacy_mode/main.md), formatting is
 Read more about [rustfmt configuration](legacy_mode/rustfmt_configuration.md) for Legacy Mode.
 
 In order to format the document, make a right click and choose `"Format Document"`.
+In Legacy Mode `"Format Selection"` is also available, although this feature of `rustfmt` is currently incomplete.
 
 ## Format On Save
 


### PR DESCRIPTION
This PR adds `DocumentRangeFormattingEditProvider` using `rustfmt --file-lines`.