### PR TITLE
Don't show the output channel if checking is an action on save

### DIFF
--- a/doc/legacy_mode/main.md
+++ b/doc/legacy_mode/main.md
@@ -36,20 +36,23 @@ You may also configure Legacy Mode via configuration parameters.
 
 ### Show Output
 
-The `"rust.showOutput"` configuration parameter controls whether the Output channel should be shown when [a Cargo command starts executing](../cargo_command_execution.md). All Cargo command other than `build` and `check` trigger this event.
+The `"rust.showOutput"` configuration parameter controls whether the output channel should be shown when [a Cargo command starts executing](../cargo_command_execution.md).
 
 The possible values:
 
 * `true` - the output channel should be shown
 * `false` - the output channel shouldn't be shown
 
-When `"rust.executeCargoCommandInTerminal"` is set to `true`, `"rust.showOutput"` has no effect.
+The output channel will not be shown under the following conditions:
 
-### Executing Cargo commands in the integrated temrinal
+- `"rust.executeCargoCommandInTerminal"` is set to `true`
+- `"rust.actionOnSave"` is set to `"check"`
+
+### Executing Cargo commands in a integrated terminal
 
 The `"rust.executeCargoCommandInTerminal"` configuration parameter controls whether [a Cargo command should be executed](../cargo_command_execution.md) in an integrated terminal.
 
-By default, the extension executes a Cargo command as a child process. It then parses the output of the command and publishes diagnostics. This is useful if you need to run a binary and enter some text.
+By default, the extension executes Cargo commands as a child process. It then parses the output of the command and publishes diagnostics. Executing Cargo commands in an integrated terminal is useful if you need to run a binary and enter some text.
 
 Unfortunately, there is currently no way to parse output of an integrated terminal. This means diagnostics cannot be shown in the editor.
 

--- a/doc/legacy_mode/main.md
+++ b/doc/legacy_mode/main.md
@@ -2,29 +2,25 @@
 
 This page describes what **Legacy Mode** is.
 
-It is how the extension worked before [Rust Language Server Mode](../rls_mode/main.md) had been added.
+It is how the extension worked before the [Rust Language Server Mode](../rls_mode/main.md) had been added.
 
 ## Description
 
 The extension supports the following features for this mode:
 
 * Formatting the active document
-* [Executing one of built-in cargo command](../cargo_command_execution.md) and showing diagnostics (warnings, errors and etc.)
+* [Executing one of the built-in Cargo commands](../cargo_command_execution.md) and showing diagnostics (warnings, errors, etc.)
 * Navigating to a symbol
 
 ## Required Tools
 
-It requires tools to function, which are:
+Legacy Mode requires the following tools to function:
 
-* racer
-* rustfmt
-* rustsym
+* `racer`
+* `rustfmt`
+* `rustsym`
 
-If any of the tools was not found the extension would suggest to install the missing tool.
-
-If the extension failed to find any of the tools the "Rust Tools Missing" item in the status bar would appear.
-
-Click on the item to install missing tools.
+If any of the tools are not found, the extension will offer to install them. A "Rust Tools Missing" item in the status bar will also appear; click on the item to install the missing tools.
 
 ## Configuration
 
@@ -34,36 +30,30 @@ The extension supports configuration of the tools:
 * [Rustfmt Configuration](rustfmt_configuration.md)
 * [Rustsym Configuration](rustsym_configuration.md)
 
-This mode supports configuration via the configuration parameters.
+You may also configure Legacy Mode via configuration parameters.
 
 ## Configuration Parameters
 
 ### Show Output
 
-The `"rust.showOutput"` configuration parameter controls whether the output channel should be shown when [a cargo command is started executing](../cargo_command_execution.md).
+The `"rust.showOutput"` configuration parameter controls whether the Output channel should be shown when [a Cargo command starts executing](../cargo_command_execution.md). All Cargo command other than `build` and `check` trigger this event.
 
 The possible values:
 
 * `true` - the output channel should be shown
 * `false` - the output channel shouldn't be shown
 
-### Execute Cargo command in a terminal
+When `"rust.executeCargoCommandInTerminal"` is set to `true`, `"rust.showOutput"` has no effect.
 
-The `"rust.executeCargoCommandInTerminal"` configuration parameter controls whether [a cargo command should be executed](../cargo_command_execution.md) in an integrated terminal.
+### Executing Cargo commands in the integrated temrinal
 
-By default, the extension executes a cargo command as a child process.
+The `"rust.executeCargoCommandInTerminal"` configuration parameter controls whether [a Cargo command should be executed](../cargo_command_execution.md) in an integrated terminal.
 
-Then it parses the output of the cargo command and publishes diagnostics.
+By default, the extension executes a Cargo command as a child process. It then parses the output of the command and publishes diagnostics. This is useful if you need to run a binary and enter some text.
 
-However, it may be changed.
-
-It is useful if you need to run a binary and enter some text.
-
-Unfortunately, there is no way to parse output of an integrated terminal.
-
-It means no diagnostics.
+Unfortunately, there is currently no way to parse output of an integrated terminal. This means diagnostics cannot be shown in the editor.
 
 The configuration parameter supports the following values:
 
-* `true` - A cargo command should be executed in an integrated terminal.
-* `false` - A cargo command should be executed as a child process.
+* `true` - A Cargo command should be executed in an integrated terminal.
+* `false` - A Cargo command should be executed as a child process.

--- a/doc/legacy_mode/main.md
+++ b/doc/legacy_mode/main.md
@@ -43,16 +43,16 @@ The possible values:
 * `true` - the output channel should be shown
 * `false` - the output channel shouldn't be shown
 
-The output channel will not be shown under the following conditions:
+The output channel will not be shown under any of the following conditions:
 
 - `"rust.executeCargoCommandInTerminal"` is set to `true`
 - `"rust.actionOnSave"` is set to `"check"`
 
-### Executing Cargo commands in a integrated terminal
+### Executing Cargo commands in an integrated terminal
 
 The `"rust.executeCargoCommandInTerminal"` configuration parameter controls whether [a Cargo command should be executed](../cargo_command_execution.md) in an integrated terminal.
 
-By default, the extension executes Cargo commands as a child process. It then parses the output of the command and publishes diagnostics. Executing Cargo commands in an integrated terminal is useful if you need to run a binary and enter some text.
+By default, the extension executes Cargo commands as child processes. It then parses the output of the command and publishes diagnostics. Executing Cargo commands in an integrated terminal is useful if you need to run a binary and enter some text.
 
 Unfortunately, there is currently no way to parse output of an integrated terminal. This means diagnostics cannot be shown in the editor.
 

--- a/src/components/cargo/cargo_manager.ts
+++ b/src/components/cargo/cargo_manager.ts
@@ -19,6 +19,20 @@ import { Task } from './task';
 
 import { TerminalTaskManager } from './terminal_task_manager';
 
+/**
+ * Possible reasons of a cargo command invocation
+ */
+export enum CommandInvocationReason {
+    /**
+     * The command is invoked because the action on save is to execute the command
+     */
+    ActionOnSave,
+    /**
+     * The command is invoked because the corresponding registered command is executed
+     */
+    CommandExecution
+}
+
 export enum BuildType {
     Debug,
     Release
@@ -126,18 +140,18 @@ class CargoTaskManager {
                 throw new Error(`Unhandled crate type=${crateType}`);
         }
 
-        this.outputChannelTaskManager.startTask('init', args, cwd, false);
+        this.outputChannelTaskManager.startTask('init', args, cwd, false, true);
     }
 
-    public invokeCargoBuildWithArgs(args: string[]): void {
-        this.runCargo('build', args, true);
+    public invokeCargoBuildWithArgs(args: string[], reason: CommandInvocationReason): void {
+        this.runCargo('build', args, true, reason);
     }
 
-    public invokeCargoBuildUsingBuildArgs(): void {
-        this.invokeCargoBuildWithArgs(UserDefinedArgs.getBuildArgs());
+    public invokeCargoBuildUsingBuildArgs(reason: CommandInvocationReason): void {
+        this.invokeCargoBuildWithArgs(UserDefinedArgs.getBuildArgs(), reason);
     }
 
-    public invokeCargoCheckWithArgs(args: string[]): void {
+    public invokeCargoCheckWithArgs(args: string[], reason: CommandInvocationReason): void {
         this.checkCargoCheckAvailability().then(isAvailable => {
             let command: string;
 
@@ -149,46 +163,46 @@ class CargoTaskManager {
                 args = args.concat('--', '-Zno-trans');
             }
 
-            this.runCargo(command, args, true);
+            this.runCargo(command, args, true, reason);
         });
     }
 
-    public invokeCargoCheckUsingCheckArgs(): void {
-        this.invokeCargoCheckWithArgs(UserDefinedArgs.getCheckArgs());
+    public invokeCargoCheckUsingCheckArgs(reason: CommandInvocationReason): void {
+        this.invokeCargoCheckWithArgs(UserDefinedArgs.getCheckArgs(), reason);
     }
 
-    public invokeCargoClippyWithArgs(args: string[]): void {
-        this.runCargo('clippy', args, true);
+    public invokeCargoClippyWithArgs(args: string[], reason: CommandInvocationReason): void {
+        this.runCargo('clippy', args, true, reason);
     }
 
-    public invokeCargoClippyUsingClippyArgs(): void {
-        this.invokeCargoClippyWithArgs(UserDefinedArgs.getClippyArgs());
+    public invokeCargoClippyUsingClippyArgs(reason: CommandInvocationReason): void {
+        this.invokeCargoClippyWithArgs(UserDefinedArgs.getClippyArgs(), reason);
     }
 
     public async invokeCargoNew(projectName: string, isBin: boolean, cwd: string): Promise<void> {
         const args = [projectName, isBin ? '--bin' : '--lib'];
 
-        await this.outputChannelTaskManager.startTask('new', args, cwd, false);
+        await this.outputChannelTaskManager.startTask('new', args, cwd, false, true);
     }
 
-    public invokeCargoRunWithArgs(args: string[]): void {
-        this.runCargo('run', args, true);
+    public invokeCargoRunWithArgs(args: string[], reason: CommandInvocationReason): void {
+        this.runCargo('run', args, true, reason);
     }
 
-    public invokeCargoRunUsingRunArgs(): void {
-        this.invokeCargoRunWithArgs(UserDefinedArgs.getRunArgs());
+    public invokeCargoRunUsingRunArgs(reason: CommandInvocationReason): void {
+        this.invokeCargoRunWithArgs(UserDefinedArgs.getRunArgs(), reason);
     }
 
-    public invokeCargoTestWithArgs(args: string[]): void {
-        this.runCargo('test', args, true);
+    public invokeCargoTestWithArgs(args: string[], reason: CommandInvocationReason): void {
+        this.runCargo('test', args, true, reason);
     }
 
-    public invokeCargoTestUsingTestArgs(): void {
-        this.invokeCargoTestWithArgs(UserDefinedArgs.getTestArgs());
+    public invokeCargoTestUsingTestArgs(reason: CommandInvocationReason): void {
+        this.invokeCargoTestWithArgs(UserDefinedArgs.getTestArgs(), reason);
     }
 
     public invokeCargo(command: string, args: string[]): void {
-        this.runCargo(command, args, true);
+        this.runCargo(command, args, true, CommandInvocationReason.CommandExecution);
     }
 
     public stopTask(): void {
@@ -210,7 +224,7 @@ class CargoTaskManager {
         return exitCode === 0;
     }
 
-    private async runCargo(command: string, args: string[], force = false): Promise<void> {
+    private async runCargo(command: string, args: string[], force: boolean, reason: CommandInvocationReason): Promise<void> {
         let cwd: string;
 
         try {
@@ -242,7 +256,13 @@ class CargoTaskManager {
                 }
             }
 
-            await this.outputChannelTaskManager.startTask(command, args, cwd, true);
+            // The output channel should be shown only if the user wants that.
+            // The only exception is checking invoked on saving the active document - in that case the output channel shouldn't be shown.
+            const shouldShowOutputChannel: boolean =
+                this.configurationManager.shouldShowRunningCargoTaskOutputChannel() &&
+                !(command === 'check' && reason === CommandInvocationReason.ActionOnSave);
+
+            await this.outputChannelTaskManager.startTask(command, args, cwd, true, shouldShowOutputChannel);
         }
     }
 }
@@ -277,24 +297,24 @@ export class CargoManager {
         this.registerCommands(context, stopCommandName);
     }
 
-    public executeBuildTask(): void {
-        this.cargoManager.invokeCargoBuildUsingBuildArgs();
+    public executeBuildTask(reason: CommandInvocationReason): void {
+        this.cargoManager.invokeCargoBuildUsingBuildArgs(reason);
     }
 
-    public executeCheckTask(): void {
-        this.cargoManager.invokeCargoCheckUsingCheckArgs();
+    public executeCheckTask(reason: CommandInvocationReason): void {
+        this.cargoManager.invokeCargoCheckUsingCheckArgs(reason);
     }
 
-    public executeClippyTask(): void {
-        this.cargoManager.invokeCargoClippyUsingClippyArgs();
+    public executeClippyTask(reason: CommandInvocationReason): void {
+        this.cargoManager.invokeCargoClippyUsingClippyArgs(reason);
     }
 
-    public executeRunTask(): void {
-        this.cargoManager.invokeCargoRunUsingRunArgs();
+    public executeRunTask(reason: CommandInvocationReason): void {
+        this.cargoManager.invokeCargoRunUsingRunArgs(reason);
     }
 
-    public executeTestTask(): void {
-        this.cargoManager.invokeCargoTestUsingTestArgs();
+    public executeTestTask(reason: CommandInvocationReason): void {
+        this.cargoManager.invokeCargoTestUsingTestArgs(reason);
     }
 
     private registerCommands(context: ExtensionContext, stopCommandName: string): void {
@@ -356,28 +376,28 @@ export class CargoManager {
     public registerCommandHelpingChooseArgsAndInvokingCargoCheck(commandName: string): vscode.Disposable {
         return vscode.commands.registerCommand(commandName, () => {
             this.customConfigurationChooser.choose('customCheckConfigurations').then(args => {
-                this.cargoManager.invokeCargoCheckWithArgs(args);
+                this.cargoManager.invokeCargoCheckWithArgs(args, CommandInvocationReason.CommandExecution);
             }, () => undefined);
         });
     }
 
     public registerCommandInvokingCargoCheckUsingCheckArgs(commandName: string): vscode.Disposable {
         return vscode.commands.registerCommand(commandName, () => {
-            this.executeCheckTask();
+            this.executeCheckTask(CommandInvocationReason.CommandExecution);
         });
     }
 
     public registerCommandHelpingChooseArgsAndInvokingCargoClippy(commandName: string): vscode.Disposable {
         return vscode.commands.registerCommand(commandName, () => {
             this.customConfigurationChooser.choose('customClippyConfigurations').then(args => {
-                this.cargoManager.invokeCargoClippyWithArgs(args);
+                this.cargoManager.invokeCargoClippyWithArgs(args, CommandInvocationReason.CommandExecution);
             }, () => undefined);
         });
     }
 
     public registerCommandInvokingCargoClippyUsingClippyArgs(commandName: string): vscode.Disposable {
         return vscode.commands.registerCommand(commandName, () => {
-            this.executeClippyTask();
+            this.executeClippyTask(CommandInvocationReason.CommandExecution);
         });
     }
 
@@ -407,42 +427,42 @@ export class CargoManager {
     public registerCommandHelpingChooseArgsAndInvokingCargoBuild(commandName: string): vscode.Disposable {
         return vscode.commands.registerCommand(commandName, () => {
             this.customConfigurationChooser.choose('customBuildConfigurations').then(args => {
-                this.cargoManager.invokeCargoBuildWithArgs(args);
+                this.cargoManager.invokeCargoBuildWithArgs(args, CommandInvocationReason.CommandExecution);
             }, () => undefined);
         });
     }
 
     public registerCommandInvokingCargoBuildUsingBuildArgs(commandName: string): vscode.Disposable {
         return vscode.commands.registerCommand(commandName, () => {
-            this.executeBuildTask();
+            this.executeBuildTask(CommandInvocationReason.CommandExecution);
         });
     }
 
     public registerCommandHelpingChooseArgsAndInvokingCargoRun(commandName: string): vscode.Disposable {
         return vscode.commands.registerCommand(commandName, () => {
             this.customConfigurationChooser.choose('customRunConfigurations').then(args => {
-                this.cargoManager.invokeCargoRunWithArgs(args);
+                this.cargoManager.invokeCargoRunWithArgs(args, CommandInvocationReason.CommandExecution);
             }, () => undefined);
         });
     }
 
     public registerCommandInvokingCargoRunUsingRunArgs(commandName: string): vscode.Disposable {
         return vscode.commands.registerCommand(commandName, () => {
-            this.executeRunTask();
+            this.executeRunTask(CommandInvocationReason.CommandExecution);
         });
     }
 
     public registerCommandHelpingChooseArgsAndInvokingCargoTest(commandName: string): vscode.Disposable {
         return vscode.commands.registerCommand(commandName, () => {
             this.customConfigurationChooser.choose('customTestConfigurations').then(args => {
-                this.cargoManager.invokeCargoTestWithArgs(args);
+                this.cargoManager.invokeCargoTestWithArgs(args, CommandInvocationReason.CommandExecution);
             }, () => undefined);
         });
     }
 
     public registerCommandInvokingCargoTestUsingTestArgs(commandName: string): vscode.Disposable {
         return vscode.commands.registerCommand(commandName, () => {
-            this.executeTestTask();
+            this.executeTestTask(CommandInvocationReason.CommandExecution);
         });
     }
 

--- a/src/components/cargo/cargo_manager.ts
+++ b/src/components/cargo/cargo_manager.ts
@@ -247,7 +247,7 @@ class CargoTaskManager {
     }
 }
 
-export default class CargoManager {
+export class CargoManager {
     private cargoManager: CargoTaskManager;
 
     private customConfigurationChooser: CustomConfigurationChooser;

--- a/src/components/cargo/output_channel_task_manager.ts
+++ b/src/components/cargo/output_channel_task_manager.ts
@@ -53,7 +53,8 @@ export class OutputChannelTaskManager {
         command: string,
         args: string[],
         cwd: string,
-        parseOutput: boolean
+        parseOutput: boolean,
+        shouldShowOutputChannnel: boolean
     ): Promise<void> {
         const cargoCwd = this.configurationManager.getCargoCwd();
 
@@ -134,7 +135,7 @@ export class OutputChannelTaskManager {
             this.channel.append(`${line}\n`);
         });
 
-        if (this.configurationManager.shouldShowRunningCargoTaskOutputChannel()) {
+        if (shouldShowOutputChannnel) {
             this.channel.show();
         }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import { ExtensionContext, window, workspace } from 'vscode';
 
-import { CargoManager } from './components/cargo/cargo_manager';
+import { CargoManager, CommandInvocationReason } from './components/cargo/cargo_manager';
 
 import { RlsConfiguration } from './components/configuration/configuration_manager';
 
@@ -95,23 +95,23 @@ function addExecutingActionOnSave(
 
         switch (actionOnSave) {
             case 'build':
-                cargoManager.executeBuildTask();
+                cargoManager.executeBuildTask(CommandInvocationReason.ActionOnSave);
                 break;
 
             case 'check':
-                cargoManager.executeCheckTask();
+                cargoManager.executeCheckTask(CommandInvocationReason.ActionOnSave);
                 break;
 
             case 'clippy':
-                cargoManager.executeClippyTask();
+                cargoManager.executeClippyTask(CommandInvocationReason.ActionOnSave);
                 break;
 
             case 'run':
-                cargoManager.executeRunTask();
+                cargoManager.executeRunTask(CommandInvocationReason.ActionOnSave);
                 break;
 
             case 'test':
-                cargoManager.executeTestTask();
+                cargoManager.executeTestTask(CommandInvocationReason.ActionOnSave);
                 break;
         }
     }));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import { ExtensionContext, window, workspace } from 'vscode';
 
-import CargoManager from './components/cargo/cargo_manager';
+import { CargoManager } from './components/cargo/cargo_manager';
 
 import { RlsConfiguration } from './components/configuration/configuration_manager';
 


### PR DESCRIPTION
This PR changes how the extension behave when checking (`Cargo: Check`) is executed because the user set `"rust.actionOnSave"` to `"check"`.
Before the PR the output channel was opened if the user hadn't set `"rust.showOutput"` to `false`.
After the PR the output channel will not be opened.
It is breaking change, but I think it is the behavior we all expect.

Fixes #129 