### PR TITLE
Handle crash

### DIFF
--- a/doc/rls_mode/main.md
+++ b/doc/rls_mode/main.md
@@ -133,6 +133,7 @@ When the extension functions in RLS mode, an indicator is displayed in the statu
 The indicator may show one of the following statuses:
 
 * `Starting` - RLS is starting, hence no features of the extension are available
+* `Crashed` - RLS has crashed, hence no features of the extensions are available
 * `Analysis started` - RLS has begun analyzing code. Features are available, but the analysis is incomplete therefore possibly inaccurate
 * `Analysis finished` - RLS has finished analyzing code. Features are available and the analysis should be accurate
 * `Stopping` - RLS has been requested to stop. Features may or may not be available

--- a/src/components/language_client/creator.ts
+++ b/src/components/language_client/creator.ts
@@ -1,17 +1,50 @@
-import { LanguageClient, LanguageClientOptions as ClientOptions, RevealOutputChannelOn, ServerOptions } from 'vscode-languageclient';
+import {
+    CloseAction,
+    ErrorAction,
+    ErrorHandler as IErrorHandler,
+    LanguageClient,
+    LanguageClientOptions as ClientOptions,
+    RevealOutputChannelOn,
+    ServerOptions
+} from 'vscode-languageclient';
+
+class ErrorHandler implements IErrorHandler {
+    private onClosed: () => void;
+
+    public constructor(onClosed: () => void) {
+        this.onClosed = onClosed;
+    }
+
+    public error(): ErrorAction {
+        return ErrorAction.Continue;
+    }
+
+    public closed(): CloseAction {
+        this.onClosed();
+
+        return CloseAction.DoNotRestart;
+    }
+}
 
 export class Creator {
     private clientOptions: ClientOptions;
 
     private serverOptions: ServerOptions;
 
-    public constructor(executable: string, args: string[] | undefined, env: any | undefined, revealOutputChannelOn: RevealOutputChannelOn) {
+    public constructor(
+        executable: string,
+        args: string[] | undefined,
+        env: any | undefined,
+        revealOutputChannelOn: RevealOutputChannelOn,
+        onClosed: () => void
+    ) {
         this.clientOptions = {
             documentSelector: ['rust'],
             revealOutputChannelOn,
             synchronize: {
                 configurationSection: 'languageServerExample'
-            }
+            },
+            errorHandler: new ErrorHandler(onClosed)
         };
 
         this.serverOptions = {

--- a/src/components/language_client/manager.ts
+++ b/src/components/language_client/manager.ts
@@ -25,7 +25,15 @@ export class Manager {
         env: any | undefined,
         revealOutputChannelOn: RevealOutputChannelOn
     ) {
-        this.languageClientCreator = new LanguageClientCreator(executable, args, env, revealOutputChannelOn);
+        this.languageClientCreator = new LanguageClientCreator(
+            executable,
+            args,
+            env,
+            revealOutputChannelOn,
+            () => {
+                this.statusBarItem.setText('Crashed');
+            }
+        );
 
         this.languageClient = this.languageClientCreator.create();
 


### PR DESCRIPTION
This PR adds a new status which is "Crashed".

It is made because before if RLS had crashed the indicator always showed "Starting" which is false.