### PR TITLE
Extend vscode-rust to support `docArgs` and `customDocConfigurations`.

### DIFF
--- a/doc/cargo_command_execution.md
+++ b/doc/cargo_command_execution.md
@@ -28,6 +28,7 @@ The possible values are:
 * `"build"` - executes `"Cargo: Build"`
 * `"check"` - executes `"Cargo: Check"`
 * `"clippy"` - executes `"Cargo: Clippy"`
+* `"doc"` - executes `"Cargo: Doc"`
 * `"run"` - executes `"Cargo: Run"`
 * `"test"` - executes `"Cargo: Test"`
 * `null` - the extension does nothing (default)
@@ -103,6 +104,7 @@ The extension supports several configuration parameters used to pass arguments o
 * `"rust.buildArgs"`
 * `"rust.checkArgs"`
 * `"rust.clippyArgs"`
+* `"rust.docArgs"`
 * `"rust.runArgs"`
 * `"rust.testArgs"`
 
@@ -113,6 +115,7 @@ These parameters are used when one of the following commands is invoked:
 * `"Cargo: Build"`
 * `"Cargo: Check"`
 * `"Cargo: Clippy"`
+* `"Cargo: Doc"`
 * `"Cargo: Run"`
 * `"Cargo: Test"`
 
@@ -129,6 +132,7 @@ The extension supports several configuration parameters:
 * `"rust.customBuildConfigurations"`
 * `"rust.customCheckConfigurations"`
 * `"rust.customClippyConfigurations"`
+* `"rust.customDocConfigurations"`
 * `"rust.customRunConfigurations"`
 * `"rust.customTestConfigurations"`
 
@@ -142,6 +146,7 @@ These configuration parameters are used when one of the following commands is in
 * `"Cargo: Build using custom configuration"`
 * `"Cargo: Check using custom configuration"`
 * `"Cargo: Clippy using custom configuration"`
+* `"Cargo: Doc using custom configuration"`
 * `"Cargo: Run using custom configuration"`
 * `"Cargo: Test using custom configuration"`
 
@@ -181,6 +186,17 @@ When one of these commands is invoked, the extension decides what to do:
 
 ```json
 "rust.customClippyConfigurations": [
+  {
+    "title": "With Features",
+    "args": ["--features", "feature1", "feature2"]
+  }
+]
+```
+
+##### Doc With Features
+
+```json
+"rust.customDocConfigurations": [
   {
     "title": "With Features",
     "args": ["--features", "feature1", "feature2"]

--- a/package.json
+++ b/package.json
@@ -32,9 +32,10 @@
     "onCommand:rust.cargo.build.custom",
     "onCommand:rust.cargo.clippy.default",
     "onCommand:rust.cargo.clippy.custom",
+    "onCommand:rust.cargo.doc.default",
+    "onCommand:rust.cargo.doc.custom",
     "onCommand:rust.cargo.run.default",
     "onCommand:rust.cargo.run.custom",
-    "onCommand:rust.cargo.doc",
     "onCommand:rust.cargo.test.default",
     "onCommand:rust.cargo.test.custom",
     "onCommand:rust.cargo.bench",
@@ -100,9 +101,14 @@
         "description": "Build and execute src/main.rs using custom configuration"
       },
       {
-        "command": "rust.cargo.doc",
+        "command": "rust.cargo.doc.default",
         "title": "Cargo: Doc",
         "description": "Build this project's and its dependencies' documentation"
+      },
+      {
+        "command": "rust.cargo.doc.custom",
+        "title": "Cargo: Doc using custom configuration",
+        "description": "Build this project's and its dependencies' documentation using custom configuration"
       },
       {
         "command": "rust.cargo.test.default",
@@ -251,6 +257,7 @@
             "build",
             "check",
             "clippy",
+            "doc",
             "run",
             "test",
             null
@@ -270,6 +277,11 @@
           "type": "array",
           "default": [],
           "description": "Arguments which is passed to cargo clippy"
+        },
+        "rust.docArgs": {
+          "type": "array",
+          "default": [],
+          "description": "Arguments which is passed to cargo doc"
         },
         "rust.runArgs": {
           "type": "array",
@@ -342,6 +354,28 @@
         "rust.customClippyConfigurations": {
           "default": [],
           "description": "Custom configurations for cargo clippy. Array of objects with `title` (string) and `args` (array of strings) which will be passed to `cargo clippy`.",
+          "items": {
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "args": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "title",
+              "args"
+            ]
+          },
+          "type": "array"
+        },
+        "rust.customDocConfigurations": {
+          "default": [],
+          "description": "Custom configurations for cargo doc. Array of objects with `title` (string) and `args` (array of strings) which will be passed to `cargo doc`.",
           "items": {
             "properties": {
               "title": {

--- a/src/components/cargo/cargo_manager.ts
+++ b/src/components/cargo/cargo_manager.ts
@@ -67,6 +67,12 @@ class UserDefinedArgs {
         return args;
     }
 
+    public static getDocArgs(): string[] {
+        const args = UserDefinedArgs.getArgs('docArgs');
+
+        return args;
+    }
+
     public static getRunArgs(): string[] {
         const args = UserDefinedArgs.getArgs('runArgs');
 
@@ -177,6 +183,14 @@ class CargoTaskManager {
 
     public invokeCargoClippyUsingClippyArgs(reason: CommandInvocationReason): void {
         this.invokeCargoClippyWithArgs(UserDefinedArgs.getClippyArgs(), reason);
+    }
+
+    public invokeCargoDocWithArgs(args: string[], reason: CommandInvocationReason): void {
+        this.runCargo('doc', args, true, reason);
+    }
+
+    public invokeCargoDocUsingDocArgs(reason: CommandInvocationReason): void {
+        this.invokeCargoDocWithArgs(UserDefinedArgs.getDocArgs(), reason);
     }
 
     public async invokeCargoNew(projectName: string, isBin: boolean, cwd: string): Promise<void> {
@@ -309,6 +323,10 @@ export class CargoManager {
         this.cargoManager.invokeCargoClippyUsingClippyArgs(reason);
     }
 
+    public executeDocTask(reason: CommandInvocationReason): void {
+        this.cargoManager.invokeCargoDocUsingDocArgs(reason);
+    }
+
     public executeRunTask(reason: CommandInvocationReason): void {
         this.cargoManager.invokeCargoRunUsingRunArgs(reason);
     }
@@ -345,7 +363,9 @@ export class CargoManager {
         context.subscriptions.push(this.registerCommandInvokingCargoWithArgs('rust.cargo.bench', 'bench'));
 
         // Cargo doc
-        context.subscriptions.push(this.registerCommandInvokingCargoWithArgs('rust.cargo.doc', 'doc'));
+        context.subscriptions.push(this.registerCommandInvokingCargoDocUsingDocArgs('rust.cargo.doc.default'));
+
+        context.subscriptions.push(this.registerCommandHelpingChooseArgsAndInvokingCargoDoc('rust.cargo.doc.custom'));
 
         // Cargo update
         context.subscriptions.push(this.registerCommandInvokingCargoWithArgs('rust.cargo.update', 'update'));
@@ -398,6 +418,20 @@ export class CargoManager {
     public registerCommandInvokingCargoClippyUsingClippyArgs(commandName: string): vscode.Disposable {
         return vscode.commands.registerCommand(commandName, () => {
             this.executeClippyTask(CommandInvocationReason.CommandExecution);
+        });
+    }
+
+    public registerCommandHelpingChooseArgsAndInvokingCargoDoc(commandName: string): vscode.Disposable {
+        return vscode.commands.registerCommand(commandName, () => {
+            this.customConfigurationChooser.choose('customDocConfigurations').then(args => {
+                this.cargoManager.invokeCargoDocWithArgs(args, CommandInvocationReason.CommandExecution);
+            }, () => undefined);
+        });
+    }
+
+    public registerCommandInvokingCargoDocUsingDocArgs(commandName: string): vscode.Disposable {
+        return vscode.commands.registerCommand(commandName, () => {
+            this.executeDocTask(CommandInvocationReason.CommandExecution);
         });
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -106,6 +106,10 @@ function addExecutingActionOnSave(
                 cargoManager.executeClippyTask(CommandInvocationReason.ActionOnSave);
                 break;
 
+            case 'doc':
+                cargoManager.executeDocTask(CommandInvocationReason.ActionOnSave);
+                break;
+
             case 'run':
                 cargoManager.executeRunTask(CommandInvocationReason.ActionOnSave);
                 break;


### PR DESCRIPTION
I don't have npm so this hasn't been tested! If someone could do so I would be grateful.

---

Adds `"rust.docArgs"` and `"rust.customDocConfigurations"` settings as well as making `"doc"` a valid target for `"rust.actionOnSave"`.