### PR TITLE
Don't follow include! expansion to origin

### DIFF
--- a/src/components/cargo/diagnostic_parser.ts
+++ b/src/components/cargo/diagnostic_parser.ts
@@ -98,7 +98,7 @@ export class DiagnosticParser {
         }
 
         // Following macro expansion to get correct file name and range.
-        while (primarySpan.expansion && primarySpan.expansion.span) {
+        while (primarySpan.expansion && primarySpan.expansion.span && primarySpan.expansion.macro_decl_name !== 'include!') {
             primarySpan = primarySpan.expansion.span;
         }
 


### PR DESCRIPTION
include! errors are special in the sense that caller side is not useful for reporting all the syntax / type errors originating in included file (as you're getting tons of messages pointing to the same line where include!(...) occurs).

This change adds special case that keeps errors bound to their original location if it was include!d.

Before:
<img width="905" alt="screen shot 2017-03-10 at 14 07 10" src="https://cloud.githubusercontent.com/assets/557590/23798100/e6466a26-059a-11e7-8830-0f4e46630f2e.png">

After:
<img width="909" alt="screen shot 2017-03-10 at 14 06 10" src="https://cloud.githubusercontent.com/assets/557590/23798104/e97ecc74-059a-11e7-8f50-0a85eb016cb0.png">
