### PR TITLE
Add installing rls

### DIFF
--- a/doc/main.md
+++ b/doc/main.md
@@ -11,6 +11,11 @@ The extension can function in one of two modes:
 * [Legacy Mode](legacy_mode/main.md)
 * [Rust Language Server Mode](rls_mode/main.md)
 
+The first mode is called *Legacy* because this mode does its best, but the second one is better.
+The second one is recommended and at some point the first one will be removed.
+
+But Legacy Mode should work just fine and if it doesn't, open an issue.
+
 Each mode is described in detail on its own page.
 
 Furthermore, the extension provides:

--- a/doc/rls_mode/main.md
+++ b/doc/rls_mode/main.md
@@ -28,6 +28,20 @@ The possible values are:
 
 ## Setting up
 
+The recommended way to set RLS up is using rustup. You should use rustup unless rustup does not suit you.
+
+If you can't answer if rustup suits you, then it suits you.
+
+### Using rustup
+
+If rustup is installed on your computer, then when the extension activates it checks if RLS is installed and if it is not, then the extension asks your permission to update rustup and install RLS.
+
+If you agree with this, the extension will do it and start itself in RLS mode.
+
+You don't have to specify either settings to make RLS work because the extension will do it automatically.
+
+### Using source
+
 First of all, you have to download the [RLS](https://github.com/rust-lang-nursery/rls) sources:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -512,11 +512,13 @@
     "typescript": "2.2.1",
     "vscode": "1.1.0",
     "@types/node": "7.0.11",
-    "@types/mocha": "2.2.40"
+    "@types/mocha": "2.2.40",
+    "@types/open": "0.0.29"
   },
   "dependencies": {
     "expand-tilde": "2.0.2",
     "tmp": "0.0.31",
+    "open": "0.0.5",
     "tree-kill": "1.1.0",
     "find-up": "2.1.0",
     "elegant-spinner": "1.0.1",

--- a/src/components/completion/completion_manager.ts
+++ b/src/components/completion/completion_manager.ts
@@ -33,6 +33,8 @@ import { fileSync } from 'tmp';
 
 import { Configuration } from '../configuration/Configuration';
 
+import { Rustup } from '../configuration/Rustup';
+
 import getDocumentFilter from '../configuration/mod';
 
 import ChildLogger from '../logging/child_logger';
@@ -127,9 +129,7 @@ export default class CompletionManager {
             return true;
         }
 
-        const rustcSysRoot = this.configuration.getRustcSysRoot();
-
-        if (rustcSysRoot && rustcSysRoot.includes('.rustup')) {
+        if (this.configuration.getRustInstallation() instanceof Rustup) {
             // tslint:disable-next-line
             const message = 'You are using rustup, but don\'t have installed source code. Do you want to install it?';
             window.showErrorMessage(message, 'Yes').then(chosenItem => {

--- a/src/components/configuration/NotRustup.ts
+++ b/src/components/configuration/NotRustup.ts
@@ -1,0 +1,21 @@
+/**
+ * Configuration of Rust installed not via Rustup, but via other variant
+ */
+export class NotRustup {
+    /**
+     * A path to Rust's installation root.
+     * It is what `rustc --print=sysroot` returns
+     */
+    private rustcSysRoot: string;
+
+    public constructor(rustcSysRoot: string) {
+        this.rustcSysRoot = rustcSysRoot;
+    }
+
+    /**
+     * Returns Rust's installation root
+     */
+    public getRustcSysRoot(): string {
+        return this.rustcSysRoot;
+    }
+}

--- a/src/components/configuration/Rustup.ts
+++ b/src/components/configuration/Rustup.ts
@@ -1,11 +1,22 @@
 import { join } from 'path';
 
+// import { EOL } from 'os';
+
+import { OutputtingProcess } from '../../OutputtingProcess';
+
 import { FileSystem } from '../file_system/FileSystem';
+
+import ChildLogger from '../logging/child_logger';
 
 /**
  * Configuration of Rust installed via Rustup
  */
 export class Rustup {
+    /**
+     * A logger to log messages
+     */
+    private logger: ChildLogger;
+
     /**
      * A path to Rust's installation root.
      * It is what `rustc --print=sysroot` returns.
@@ -17,6 +28,12 @@ export class Rustup {
      * It can be undefined if the component "rust-src" is not installed
      */
     private pathToRustSourceCode: string | undefined;
+
+    /**
+     * A path to the executable of RLS.
+     * It can be undefined if the component "rls" is not installed
+     */
+    private pathToRlsExecutable: string | undefined;
 
     /**
      * Checks if Rustup manages a specified Rust's installation root
@@ -33,10 +50,12 @@ export class Rustup {
      * The method is asynchronous because it tries to find Rust's source code
      * @param pathToRustcSysRoot A path to Rust's installation root
      */
-    public static async create(pathToRustcSysRoot: string): Promise<Rustup> {
-        const rustup = new Rustup(pathToRustcSysRoot, undefined);
+    public static async create(logger: ChildLogger, pathToRustcSysRoot: string): Promise<Rustup> {
+        const rustup = new Rustup(logger, pathToRustcSysRoot, undefined, undefined);
 
         await rustup.updatePathToRustSourceCodePath();
+
+        await rustup.updatePathToRlsExecutable();
 
         return rustup;
     }
@@ -56,7 +75,15 @@ export class Rustup {
     }
 
     /**
-     * Checks if Rust's source code is installed at the expected path and sets the field `pathToRustSourceCode` if it is.
+     * Returns either the path to the executable of RLS or undefined
+     */
+    public getPathToRlsExecutable(): string | undefined {
+        return this.pathToRlsExecutable;
+    }
+
+    /**
+     * Checks if Rust's source code is installed at the expected path.
+     * This method assigns either the expected path or undefined to the field `pathToRustSourceCode`, depending on if the expected path exists.
      * The method is asynchronous because it checks if the expected path exists
      */
     public async updatePathToRustSourceCodePath(): Promise<void> {
@@ -72,14 +99,113 @@ export class Rustup {
     }
 
     /**
+     * Checks if the executable of RLS is installed.
+     * This method assigns either a path to the executable or undefined to the field `pathToRlsExecutable`, depending on if the executable is found
+     * This method is asynchronous because it checks if the executable exists
+     */
+    public async updatePathToRlsExecutable(): Promise<void> {
+        const logger = this.logger.createChildLogger('updatePathToRlsExecutable: ');
+
+        const installedComponents: string[] | undefined = await this.getInstalledComponents();
+
+        if (!installedComponents) {
+            this.pathToRlsExecutable = undefined;
+
+            return;
+        }
+
+        const rlsComponent = installedComponents.find(component => {
+            return component.startsWith('rls');
+        });
+
+        const isRlsInstalled = rlsComponent !== undefined;
+
+        if (!isRlsInstalled) {
+            logger.debug('RLS is not installed');
+
+            this.pathToRlsExecutable = undefined;
+        }
+
+        const pathToRlsExecutable: string | undefined = await FileSystem.findExecutablePath('rls');
+
+        if (!pathToRlsExecutable) {
+            // RLS is installed via Rustup, but isn't found. Let a user know about it
+            logger.error(`Rustup had reported that RLS had been installed, but RLS wasn't found in PATH=${process.env.PATH}`);
+
+            this.pathToRlsExecutable = undefined;
+
+            return;
+        }
+
+        this.pathToRlsExecutable = pathToRlsExecutable;
+
+        logger.debug(`RLS is installed. Path=${this.pathToRlsExecutable}`);
+    }
+
+    /**
      * Constructs a new instance of the class.
      * The constructor is private because creating a new instance should be done via the method `create`
+     * @param logger A value for the field `logger`
      * @param pathToRustcSysRoot A value for the field `pathToRustcSysRoot`
      * @param pathToRustSourceCode A value for the field `pathToRustSourceCode`
+     * @param pathToRlsExecutable A value fo the field `pathToRlsExecutable`
      */
-    private constructor(pathToRustcSysRoot: string, pathToRustSourceCode: string | undefined) {
+    private constructor(
+        logger: ChildLogger,
+        pathToRustcSysRoot: string,
+        pathToRustSourceCode: string | undefined,
+        pathToRlsExecutable: string | undefined
+    ) {
+        this.logger = logger;
+
         this.pathToRustcSysRoot = pathToRustcSysRoot;
 
         this.pathToRustSourceCode = pathToRustSourceCode;
+
+        this.pathToRlsExecutable = pathToRlsExecutable;
+    }
+
+    /**
+     * Requests Rustup give a list of installed components, parses it and returns it
+     * @returns a list of installed components if no error occurred otherwise undefined
+     */
+    private async getInstalledComponents(): Promise<string[] | undefined> {
+        const logger = this.logger.createChildLogger('getInstalledComponents: ');
+
+        const rustupExe = 'rustup';
+
+        const args = ['component', 'list'];
+
+        // We assume that the executable of Rustup can be called since usually both `rustc` and `rustup` are placed in the same directory
+        const output = await OutputtingProcess.spawn(rustupExe, ['component', 'list'], undefined);
+
+        if (!output.success) {
+            // It actually shouldn't happen.
+            // If it happens, then there is some problem and we need to know about it
+            logger.error(`failed to execute ${rustupExe}`);
+
+            return undefined;
+        }
+
+        if (output.exitCode !== 0) {
+            logger.error(`${rustupExe} ${args.join(' ')} exited with code=${output.exitCode}, but zero is expected`);
+
+            return undefined;
+        }
+
+        const components: string[] = output.stdoutData.split('\n');
+
+        if (components.length === 0) {
+            // It actually shouldn't happen, but sometimes strange things happen
+            logger.error(`${rustupExe} ${args.join(' ')} returned no output`);
+
+            return undefined;
+        }
+
+        const installedComponents = components.filter(component => {
+            return component.endsWith(' (installed)');
+        });
+
+        return installedComponents;
     }
 }

--- a/src/components/configuration/Rustup.ts
+++ b/src/components/configuration/Rustup.ts
@@ -1,0 +1,85 @@
+import { join } from 'path';
+
+import { FileSystem } from '../file_system/FileSystem';
+
+/**
+ * Configuration of Rust installed via Rustup
+ */
+export class Rustup {
+    /**
+     * A path to Rust's installation root.
+     * It is what `rustc --print=sysroot` returns.
+     */
+    private pathToRustcSysRoot: string;
+
+    /**
+     * A path to Rust's source code.
+     * It can be undefined if the component "rust-src" is not installed
+     */
+    private pathToRustSourceCode: string | undefined;
+
+    /**
+     * Checks if Rustup manages a specified Rust's installation root
+     * @param rustcSysRoot a path to Rust's installation root to check
+     * @returns true if Rustup manages it otherwire false
+     */
+    public static doesManageRustcSysRoot(pathToRustcSysRoot: string): boolean {
+        // It can be inaccurate since nobody can stop a user from installing Rust not via Rustup, but to `.rustup` directory
+        return pathToRustcSysRoot.includes('.rustup');
+    }
+
+    /**
+     * Creates a new instance of the class.
+     * The method is asynchronous because it tries to find Rust's source code
+     * @param pathToRustcSysRoot A path to Rust's installation root
+     */
+    public static async create(pathToRustcSysRoot: string): Promise<Rustup> {
+        const rustup = new Rustup(pathToRustcSysRoot, undefined);
+
+        await rustup.updatePathToRustSourceCodePath();
+
+        return rustup;
+    }
+
+    /**
+     * Returns the path to Rust's installation root
+     */
+    public getPathToRustcSysRoot(): string {
+        return this.pathToRustcSysRoot;
+    }
+
+    /**
+     * Returns the path to Rust's source code
+     */
+    public getPathToRustSourceCode(): string | undefined {
+        return this.pathToRustSourceCode;
+    }
+
+    /**
+     * Checks if Rust's source code is installed at the expected path and sets the field `pathToRustSourceCode` if it is.
+     * The method is asynchronous because it checks if the expected path exists
+     */
+    public async updatePathToRustSourceCodePath(): Promise<void> {
+        const pathToRustSourceCode = join(this.pathToRustcSysRoot, 'lib', 'rustlib', 'src', 'rust', 'src');
+
+        const isRustSourceCodeInstalled: boolean = await FileSystem.doesFileOrDirectoryExists(pathToRustSourceCode);
+
+        if (isRustSourceCodeInstalled) {
+            this.pathToRustSourceCode = pathToRustSourceCode;
+        } else {
+            this.pathToRustSourceCode = undefined;
+        }
+    }
+
+    /**
+     * Constructs a new instance of the class.
+     * The constructor is private because creating a new instance should be done via the method `create`
+     * @param pathToRustcSysRoot A value for the field `pathToRustcSysRoot`
+     * @param pathToRustSourceCode A value for the field `pathToRustSourceCode`
+     */
+    private constructor(pathToRustcSysRoot: string, pathToRustSourceCode: string | undefined) {
+        this.pathToRustcSysRoot = pathToRustcSysRoot;
+
+        this.pathToRustSourceCode = pathToRustSourceCode;
+    }
+}

--- a/src/components/file_system/FileSystem.ts
+++ b/src/components/file_system/FileSystem.ts
@@ -1,0 +1,21 @@
+import { access } from 'fs';
+
+/**
+ * Code related to file system
+ */
+export class FileSystem {
+    /**
+     * Checks if there is a file or a directory at a specified path
+     * @param path a path to check
+     * @return true if there is a file or a directory otherwise false
+     */
+    public static doesFileOrDirectoryExists(path: string): Promise<boolean> {
+        return new Promise<boolean>(resolve => {
+            access(path, err => {
+                const pathExists = !err;
+
+                resolve(pathExists);
+            });
+        });
+    }
+}

--- a/src/components/file_system/FileSystem.ts
+++ b/src/components/file_system/FileSystem.ts
@@ -1,5 +1,7 @@
 import { access } from 'fs';
 
+import { delimiter, extname, join } from 'path';
+
 /**
  * Code related to file system
  */
@@ -17,5 +19,36 @@ export class FileSystem {
                 resolve(pathExists);
             });
         });
+    }
+
+    /**
+     * Looks for a specified executable at paths specified in the environment variable PATH
+     * @param executable an executable to look for
+     * @return A path to the executable if it has been found otherwise undefined
+     */
+    public static async findExecutablePath(executable: string): Promise<string | undefined> {
+        if (!process.env.PATH) {
+            return undefined;
+        }
+
+        // A executable on Windows ends with ".exe".
+        // Since this method can be called without the extension we need to add it if it is necessary
+        if (process.platform === 'win32' && extname(executable).length === 0) {
+            executable += '.exe';
+        }
+
+        const paths: string[] = process.env.PATH.split(delimiter);
+
+        for (const path of paths) {
+            const possibleExecutablePath = join(path, executable);
+
+            const doesPathExist: boolean = await FileSystem.doesFileOrDirectoryExists(possibleExecutablePath);
+
+            if (doesPathExist) {
+                return possibleExecutablePath;
+            }
+        }
+
+        return undefined;
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,6 @@
+// https://github.com/pwnall/node-open
+import open = require('open');
+
 import { ExtensionContext, window, workspace } from 'vscode';
 
 import { CargoManager, CommandInvocationReason } from './components/cargo/cargo_manager';
@@ -5,6 +8,10 @@ import { CargoManager, CommandInvocationReason } from './components/cargo/cargo_
 import { Configuration } from './components/configuration/Configuration';
 
 import CurrentWorkingDirectoryManager from './components/configuration/current_working_directory_manager';
+
+import { NotRustup } from './components/configuration/NotRustup';
+
+import { Rustup } from './components/configuration/Rustup';
 
 import { Manager as LanguageClientManager } from './components/language_client/manager';
 
@@ -14,12 +21,174 @@ import RootLogger from './components/logging/root_logger';
 
 import LegacyModeManager from './legacy_mode_manager';
 
+enum UserDecisionAboutInstallingRlsViaRustup {
+    ReadAboutRls,
+    InstallRls,
+    Decline
+}
+
+/**
+ * Checks if Rust is installed via Rustup, then asks a user to install it if it is possible
+ * @param logger A logger
+ * @param configuration A configuration
+ */
+async function askForInstallingRlsViaRustup(
+    logger: RootLogger,
+    configuration: Configuration
+): Promise<UserDecisionAboutInstallingRlsViaRustup> {
+    const methodLogger = logger.createChildLogger('askForInstallingRlsViaRustup: ');
+
+    const rustInstallation: Rustup | NotRustup | undefined = configuration.getRustInstallation();
+
+    if (!(rustInstallation instanceof Rustup)) {
+        methodLogger.error('Rust is either not installed or installed not via Rustup. The method should not have been called');
+
+        return UserDecisionAboutInstallingRlsViaRustup.Decline;
+    }
+
+    const readAboutRlsChoice = 'Read about RLS';
+
+    const installRlsChoice = 'Install RLS';
+
+    const choice: string | undefined = await window.showInformationMessage(
+        'You use Rustup, but RLS was not found. RLS provides a good user experience',
+        readAboutRlsChoice,
+        installRlsChoice
+    );
+
+    switch (choice) {
+        case readAboutRlsChoice:
+            methodLogger.debug('A user decided to read about RLS');
+
+            return UserDecisionAboutInstallingRlsViaRustup.ReadAboutRls;
+
+        case installRlsChoice:
+            methodLogger.debug('A user decided to install RLS');
+
+            return UserDecisionAboutInstallingRlsViaRustup.InstallRls;
+
+        default:
+            methodLogger.debug('A user declined');
+
+            return UserDecisionAboutInstallingRlsViaRustup.Decline;
+    }
+}
+
+/**
+ * Asks a user if the user agrees to update Rustup
+ * @param updatePurpose A reason to update which is shown to a user
+ * @returns true if a user agreed to update otherwise false
+ */
+async function askUserToUpdateRustup(updatePurpose: string): Promise<boolean> {
+    const updateChoice = 'Update';
+
+    const choice = await window.showInformationMessage(updatePurpose, updateChoice);
+
+    return choice === updateChoice;
+}
+
+/**
+ * Checks if Rustup can install (because older versions of Rustup cannot) and installs it if it Rustup can do it
+ * @param logger A logger
+ * @param rustup A rustup
+ * @returns true if RLS has been installed otherwise false
+ */
+async function handleUserDecisionToInstallRls(logger: RootLogger, rustup: Rustup): Promise<boolean> {
+    const methodLogger = logger.createChildLogger('handleUserDecisionToInstallRls: ');
+
+    const didUserAgreeToUpdateRustup = await askUserToUpdateRustup('Before installing RLS it would be good to update Rustup. If you decline to update, RLS will not be installed');
+
+    if (!didUserAgreeToUpdateRustup) {
+        methodLogger.debug('A user declined to update rustup');
+
+        return false;
+    }
+
+    methodLogger.debug('A user agreed to update rustup');
+
+    const didRustupUpdateSuccessfully: boolean = await rustup.update();
+
+    if (!didRustupUpdateSuccessfully) {
+        methodLogger.error('Rustup failed to update');
+
+        return false;
+    }
+
+    methodLogger.debug('Rustup has updated successfully');
+
+    const canRustupInstallRls = await rustup.canInstallRls();
+
+    if (!canRustupInstallRls) {
+        methodLogger.error('Rustup cannot install RLS');
+
+        return false;
+    }
+
+    methodLogger.debug('Rustup can install RLS');
+
+    return await rustup.installRls();
+}
+
 export async function activate(ctx: ExtensionContext): Promise<void> {
     const loggingManager = new LoggingManager();
 
     const logger = loggingManager.getLogger();
 
     const configuration = await Configuration.create(logger.createChildLogger('Configuration: '));
+
+    // The following if statement does the following:
+    // * It checks if RLS is installed via any way
+    //  * If it is, then it stops
+    //  * Otherwise it checks if Rust is installed via Rustup
+    //   * If it is, then it asks a user if the user wants to install RLS
+    //    * If a user agrees to install RLS
+    //     * It installs RLS
+    //   * Otherwise it shows an error message
+    if (!configuration.getPathToRlsExecutable()) {
+        const rustInstallation = configuration.getRustInstallation();
+
+        if (rustInstallation instanceof Rustup) {
+            // Asking a user if the user wants to install RLS until the user declines it or agrees to install it.
+            // A user can decide to install RLS, then we install it.
+            // A user can decide to read about RLS, then we open a link to the repository of RLS and ask again after
+
+            let shouldStop = false;
+
+            while (!shouldStop) {
+                const userDecision: UserDecisionAboutInstallingRlsViaRustup = await askForInstallingRlsViaRustup(logger, configuration);
+
+                switch (userDecision) {
+                    case UserDecisionAboutInstallingRlsViaRustup.Decline:
+                        shouldStop = true;
+
+                        break;
+
+                    case UserDecisionAboutInstallingRlsViaRustup.InstallRls: {
+                        const isRlsInstalled: boolean = await handleUserDecisionToInstallRls(logger, rustInstallation);
+
+                        if (isRlsInstalled) {
+                            await window.showInformationMessage('RLS has been installed successfully');
+                        } else {
+                            await window.showErrorMessage('RLS has not been installed. Check the output channel "Rust Logging"');
+                        }
+
+                        shouldStop = true;
+
+                        break;
+                    }
+
+                    case UserDecisionAboutInstallingRlsViaRustup.ReadAboutRls:
+                        open('https://github.com/rust-lang-nursery/rls');
+
+                        break;
+                }
+            }
+        } else {
+            logger.debug('Rust is either not installed or installed not via Rustup');
+
+            await window.showInformationMessage('You do not use Rustup. Rustup is a preffered way to install Rust and its components');
+        }
+    }
 
     const currentWorkingDirectoryManager = new CurrentWorkingDirectoryManager();
 

--- a/tslint.json
+++ b/tslint.json
@@ -20,10 +20,6 @@
     "interface-name": false,
     "jsdoc-format": true,
     "label-position": true,
-    "max-line-length": [
-      true,
-      140
-    ],
     "member-access": true,
     "member-ordering": [
       false,


### PR DESCRIPTION
Fixes #177 

After this PR:
* the documentation will be extended to describe a new way to set RLS up
* the extension will:
  * determine:
    * if a user uses Rustup
    * if RLS is installed
    * if RLS can be installed via RLS
  * ask a user to update Rustup before installing RLS
  * ask a user to install RLS
  * use RLS installed via Rustup by default (There is no need to specify rust.rls.executable if RLS is installed via Rustup)

For those who wants to try it out:

[GitHub documentation](https://help.github.com/articles/checking-out-pull-requests-locally/)
[The page "Install the extension from source" in the extension's documentation](https://github.com/editor-rs/vscode-rust/blob/master/doc/install_extension_from_source.md)

```
git clone https://github.com/editor-rs/vscode-rust.git
cd vscode-rust
git fetch origin pull/181/head:pull-181
git checkout pull-181
npm install
code .
```

Then Press F5
