### PR TITLE
Formatting is not available if rustfmt is not installed

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -193,7 +193,7 @@ async function chooseModeAndRun(
     if (pathToRlsExecutable) {
         runInRlsMode(context, logger, configuration, pathToRlsExecutable);
     } else {
-        const legacyModeManager = new LegacyModeManager(
+        const legacyModeManager = await LegacyModeManager.create(
             context,
             configuration,
             currentWorkingDirectoryManager,

--- a/src/legacy_mode_manager.ts
+++ b/src/legacy_mode_manager.ts
@@ -1,5 +1,4 @@
 import { ExtensionContext } from 'vscode';
-
 import { Configuration } from './components/configuration/Configuration';
 
 import CurrentWorkingDirectoryManager
@@ -21,62 +20,55 @@ import MissingToolsInstallator from './components/tools_installation/installator
 
 export default class LegacyModeManager {
     private context: ExtensionContext;
-
     private configuration: Configuration;
-
     private completionManager: CompletionManager;
-
-    private formattingManager: FormattingManager;
-
+    private formattingManager: FormattingManager | undefined;
     private workspaceSymbolProvisionManager: WorkspaceSymbolProvisionManager;
-
     private documentSymbolProvisionManager: DocumentSymbolProvisionManager;
-
     private missingToolsInstallator: MissingToolsInstallator;
 
-    public constructor(
+    public static async create(
         context: ExtensionContext,
         configuration: Configuration,
         currentWorkingDirectoryManager: CurrentWorkingDirectoryManager,
         logger: ChildLogger
+    ): Promise<LegacyModeManager> {
+        const formattingManager: FormattingManager | undefined = await FormattingManager.create(context, configuration);
+        return new LegacyModeManager(context, configuration, currentWorkingDirectoryManager, logger, formattingManager);
+    }
+
+    public async start(): Promise<void> {
+        this.context.subscriptions.push(this.completionManager.disposable());
+        await this.configuration.updatePathToRacer();
+        await this.missingToolsInstallator.addStatusBarItemIfSomeToolsAreMissing();
+        await this.completionManager.initialStart();
+    }
+
+    private constructor(
+        context: ExtensionContext,
+        configuration: Configuration,
+        currentWorkingDirectoryManager: CurrentWorkingDirectoryManager,
+        logger: ChildLogger,
+        formattingManager: FormattingManager | undefined
     ) {
         this.context = context;
-
         this.configuration = configuration;
-
         this.completionManager = new CompletionManager(
             context,
             configuration,
             logger.createChildLogger('CompletionManager: ')
         );
-
-        this.formattingManager = new FormattingManager(context, configuration);
-
+        this.formattingManager = formattingManager;
         this.workspaceSymbolProvisionManager = new WorkspaceSymbolProvisionManager(
             context,
             configuration,
             currentWorkingDirectoryManager
         );
-
-        this.documentSymbolProvisionManager = new DocumentSymbolProvisionManager(
-            context,
-            configuration
-        );
-
+        this.documentSymbolProvisionManager = new DocumentSymbolProvisionManager(context, configuration);
         this.missingToolsInstallator = new MissingToolsInstallator(
             context,
             configuration,
             logger.createChildLogger('MissingToolsInstallator: ')
         );
-    }
-
-    public async start(): Promise<void> {
-        this.context.subscriptions.push(this.completionManager.disposable());
-
-        await this.configuration.updatePathToRacer();
-
-        await this.missingToolsInstallator.addStatusBarItemIfSomeToolsAreMissing();
-
-        await this.completionManager.initialStart();
     }
 }


### PR DESCRIPTION
Fixed #188 

After this PR have been merged, the extension will not provide the ability to format the document if rustfmt is not installed.
It is related to Legacy Mode.