### PR TITLE
Log errors when racer cannot be started

### DIFF
--- a/src/components/completion/completion_manager.ts
+++ b/src/components/completion/completion_manager.ts
@@ -88,12 +88,12 @@ export class CompletionManager {
         const logger = this.logger.createChildLogger('initialStart: ');
         const pathToRacer: string | undefined = this.configuration.getPathToRacer();
         if (!pathToRacer) {
-            logger.createChildLogger('racer is not installed');
+            logger.debug('racer is not installed');
             return;
         }
         const isSourceCodeAvailable: boolean = this.ensureSourceCodeIsAvailable();
         if (!isSourceCodeAvailable) {
-            logger.createChildLogger('Rust\'s source is not installed');
+            logger.debug('Rust\'s source is not installed');
             return;
         }
         this.start(pathToRacer);


### PR DESCRIPTION
Currently when [racer](https://github.com/phildawes/racer) cannot be started, it show not errors.
Because of the problem there was a confusing in #256.