### PR TITLE
Make cargo use rustup

### DIFF
--- a/doc/common_configuration_parameters.md
+++ b/doc/common_configuration_parameters.md
@@ -7,6 +7,6 @@ Users should adjust properties of this configuration parameter to customize rust
 ### toolchain
 
 This configuration parameter specifies which toolchain the extension will invoke rustup with.
-It is used for getting sysroot, installing components.
+It is used for getting sysroot, installing components, invoking Cargo
 
 However there are few exceptions. Currently RLS is available for nightly hence RLS and rust-analysis are installed for the nightly toolchain.

--- a/src/CargoInvocationManager.ts
+++ b/src/CargoInvocationManager.ts
@@ -1,0 +1,34 @@
+import { Configuration } from './components/configuration/Configuration';
+import { Rustup } from './components/configuration/Rustup';
+
+/**
+ * The class defines functions which can be used to get data required to invoke Cargo
+ */
+export class CargoInvocationManager {
+    private _configuration: Configuration;
+    private _rustup: Rustup | undefined;
+
+    public constructor(configuration: Configuration, rustup: Rustup | undefined) {
+        this._configuration = configuration;
+        this._rustup = rustup;
+    }
+
+    /**
+     * Cargo can be accessible from multiple places, but the only one is correct.
+     * This function determines the path to the executable which either Cargo itself or proxy to
+     * Cargo. If the executable is a proxy to Cargo, then the proxy may require some arguments to
+     * understand that Cargo is requested. An example is running Cargo using rustup.
+     */
+    public getExecutableAndArgs(): { executable: string, args: string[] } {
+        const userCargoPath = this._configuration.getCargoPath();
+        if (userCargoPath) {
+            return { executable: userCargoPath, args: [] };
+        }
+        const userToolchain = this._rustup ? this._rustup.getUserToolchain() : undefined;
+        if (!userToolchain) {
+            return { executable: 'cargo', args: [] };
+        }
+        const args = ['run', userToolchain.toString(true, false), 'cargo'];
+        return { executable: Rustup.getRustupExecutable(), args };
+    }
+}

--- a/src/components/cargo/CargoManager.ts
+++ b/src/components/cargo/CargoManager.ts
@@ -1,5 +1,6 @@
 import * as tmp from 'tmp';
 import { Disposable, ExtensionContext, Uri, commands, window, workspace } from 'vscode';
+import { CargoInvocationManager } from '../../CargoInvocationManager';
 import { Configuration } from '../configuration/Configuration';
 import { CurrentWorkingDirectoryManager }
     from '../configuration/current_working_directory_manager';
@@ -17,6 +18,7 @@ export class CargoManager {
     public constructor(
         context: ExtensionContext,
         configuration: Configuration,
+        cargoInvocationManager: CargoInvocationManager,
         currentWorkingDirectoryManager: CurrentWorkingDirectoryManager,
         logger: ChildLogger
     ) {
@@ -24,6 +26,7 @@ export class CargoManager {
         this._cargoTaskManager = new CargoTaskManager(
             context,
             configuration,
+            cargoInvocationManager,
             currentWorkingDirectoryManager,
             logger.createChildLogger('CargoTaskManager: '),
             stopCommandName

--- a/src/components/cargo/output_channel_task_manager.ts
+++ b/src/components/cargo/output_channel_task_manager.ts
@@ -31,6 +31,7 @@ export class OutputChannelTaskManager {
 
     public async startTask(
         executable: string,
+        preCommandArgs: string[],
         command: string,
         args: string[],
         cwd: string,
@@ -54,7 +55,7 @@ export class OutputChannelTaskManager {
             }
         }
         prependArgsWithMessageFormatIfRequired();
-        args = [command].concat(args);
+        args = preCommandArgs.concat(command, ...args);
         this.runningTask = new Task(
             this.configuration,
             this.logger.createChildLogger('Task: '),
@@ -65,7 +66,7 @@ export class OutputChannelTaskManager {
         this.runningTask.setStarted(() => {
             this.channel.clear();
             this.channel.append(`Working directory: ${cwd}\n`);
-            this.channel.append(`Started cargo ${args.join(' ')}\n\n`);
+            this.channel.append(`Started ${executable} ${args.join(' ')}\n\n`);
             this.diagnostics.clear();
         });
         this.runningTask.setLineReceivedInStdout(line => {

--- a/src/components/cargo/terminal_task_manager.ts
+++ b/src/components/cargo/terminal_task_manager.ts
@@ -31,8 +31,14 @@ export class TerminalTaskManager {
         }
     }
 
-    public async startTask(executable: string, command: string, args: string[], cwd: string): Promise<void> {
-        args = [command].concat(args);
+    public async startTask(
+        executable: string,
+        preCommandArgs: string[],
+        command: string,
+        args: string[],
+        cwd: string
+    ): Promise<void> {
+        args = preCommandArgs.concat(command, ...args);
         const terminal = window.createTerminal('Cargo Task');
         this._runningTerminal = terminal;
         const shell = parseShell(workspace.getConfiguration('terminal')['integrated']['shell']['windows']);

--- a/src/components/configuration/Configuration.ts
+++ b/src/components/configuration/Configuration.ts
@@ -206,8 +206,8 @@ export class Configuration {
         return Configuration.getPathConfigParameter('cargoCwd');
     }
 
-    public getCargoPath(): string {
-        return Configuration.getPathConfigParameterOrDefault('cargoPath', 'cargo');
+    public getCargoPath(): string | undefined {
+        return Configuration.getPathConfigParameter('cargoPath');
     }
 
     public getCargoHomePath(): string | undefined {

--- a/src/components/configuration/Rustup.ts
+++ b/src/components/configuration/Rustup.ts
@@ -48,6 +48,14 @@ export class Rustup {
      */
     private _userToolchain: Toolchain | undefined;
 
+
+    /**
+     * Returns the executable of Rustup
+     */
+    public static getRustupExecutable(): string {
+        return 'rustup';
+    }
+
     /**
      * Creates a new instance of the class.
      * The method is asynchronous because it tries to find Rust's source code
@@ -371,13 +379,6 @@ export class Rustup {
         }
         const componentInstalled: boolean = component.endsWith(Rustup.getSuffixForInstalledComponent());
         return !componentInstalled;
-    }
-
-    /**
-     * Returns the executable of Rustup
-     */
-    private static getRustupExecutable(): string {
-        return 'rustup';
     }
 
     /**


### PR DESCRIPTION
Before the PR, how to invoke Cargo was determined as follows:
* If the user specified `"rust.cargoPath"`, then the extension used it.
* Just `cargo` (basically it meant the first available one)
After the PR, how to invoke Cargo will be determined as follows:
* If the user specifies `"rust.cargoPath"`, then the extension will use it.
* If rustup is installed and the user chooses "`rustup.toolchain"`, then the extension will invoke Cargo as follows: `rustup run <user toolchain> cargo ...`
* Just `cargo` (basically it meant the first available one)
I'm going to keep the PR open at least for 24 hours.
If you have any objections, suggestions, speak up please.