### PR TITLE
Remove surrounding racer path with double quotes

### DIFF
--- a/src/components/completion/completion_manager.ts
+++ b/src/components/completion/completion_manager.ts
@@ -7,7 +7,6 @@ import { ChildProcess, SpawnOptions, spawn } from 'child_process';
 import { writeFileSync } from 'fs';
 import { CompletionItem, CompletionItemKind, Definition, Disposable, ExtensionContext, Hover, Location, MarkedString, ParameterInformation, Position, Range, SignatureHelp, SignatureInformation, TextDocument, Uri, commands, languages, window, workspace } from 'vscode';
 import { fileSync } from 'tmp';
-import { surround_by_double_quotes } from '../../Utils';
 import { Configuration } from '../configuration/Configuration';
 import { RustSource } from '../configuration/RustSource';
 import { Rustup } from '../configuration/Rustup';
@@ -165,13 +164,11 @@ export class CompletionManager {
         this.errorBuffer = '';
         this.lastCommand = '';
         this.providers = [];
-        racerPath = surround_by_double_quotes(racerPath);
         logger.debug(`racerPath=${racerPath}`);
         this.racerStatusBarItem.showTurnedOn();
         const cargoHomePath = this.configuration.getCargoHomePath();
         const racerSpawnOptions: SpawnOptions = {
             stdio: 'pipe',
-            shell: true,
             env: Object.assign({}, process.env)
         };
         const rustSourcePath = this._rustSource.getPath();


### PR DESCRIPTION
Fixes #304

I don't think we need `shell: true` anymore because it has been added to allow running racer which is available from the terminal, but unavailable from PATH (such case happens when VSCode is started from, i.e., Launchpad (MacOS)).
It was not consistent - only racer was started with `shell: true` hence you, developers, shouldn't experience any troubles.
