### PR TITLE
Correctly dispose existing terminal for Cargo tasks

### DIFF
--- a/src/components/cargo/CargoTaskManager.ts
+++ b/src/components/cargo/CargoTaskManager.ts
@@ -152,7 +152,7 @@ export class CargoTaskManager {
         shouldUseUserWorkingDirectory: boolean,
         shouldParseOutput: boolean
     ): Promise<void> {
-        const canStartTask = this.processPossiblyRunningTask(
+        const canStartTask = await this.processPossiblyRunningTask(
             isStoppingRunningTaskAllowed,
             shouldStartTaskInTerminal
         );

--- a/src/components/cargo/CargoTaskManager.ts
+++ b/src/components/cargo/CargoTaskManager.ts
@@ -226,7 +226,7 @@ export class CargoTaskManager {
         if (!hasRunningTask) {
             return true;
         }
-        if (isStoppingRunningTaskAllowed) {
+        if (!isStoppingRunningTaskAllowed) {
             return false;
         }
         let shouldStopRunningTask = false;


### PR DESCRIPTION
Problem: existing Cargo task terminal is not correctly terminated even if `isStoppingRunningTaskAllowed` is set to `true`.

PS: I've been away from JavaScript for quite long. Please let me know if there's anything wrong with this PR.

Fixed #333 