### PR TITLE
Ask what configuration to save the kind of windows shell in

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "email": "kalita.alexey@outlook.com"
   },
   "engines": {
-    "vscode": "^1.8.0"
+    "vscode": "^1.12.0"
   },
   "categories": [
     "Languages",

--- a/src/ConfigurationParameter.ts
+++ b/src/ConfigurationParameter.ts
@@ -15,8 +15,14 @@ export class ConfigurationParameter {
         return this.getConfiguration().get(this._parameterName);
     }
 
-    public async setValue(value: any): Promise<void> {
-        await this.getConfiguration().update(this._parameterName, value, true);
+    /**
+     * Sets the value in either the user configuration or the workspace configuration
+     * @param value The value to set
+     * @param setToUserConfiguration The flag indicating if the value has to be set to the user settings instead
+     * of the workspace settings
+     */
+    public async setValue(value: any, setToUserConfiguration: boolean): Promise<void> {
+        await this.getConfiguration().update(this._parameterName, value, setToUserConfiguration);
     }
 
     private getConfiguration(): WorkspaceConfiguration {

--- a/src/UserInteraction/AskUserToAnswerYesOrNo.ts
+++ b/src/UserInteraction/AskUserToAnswerYesOrNo.ts
@@ -1,0 +1,13 @@
+import { MessageItem, window } from 'vscode';
+
+/**
+ * Shows the user the dialog with the specified message and two choices: Yes or No
+ * @param message The message to show to the user
+ * @return The flag indicating whether the Yes choice has been chosen
+ */
+export default async function askUserToAnswerYesOrNo(message: string): Promise<boolean> {
+    const yesChoice: MessageItem = { title: 'Yes' };
+    const noChoice: MessageItem = { title: 'No', isCloseAffordance: true };
+    const choice = await window.showInformationMessage(message, { modal: true }, yesChoice, noChoice);
+    return choice === yesChoice;
+}

--- a/src/UserInteraction/AskUserWhatConfigurationToSaveParameterIn.ts
+++ b/src/UserInteraction/AskUserWhatConfigurationToSaveParameterIn.ts
@@ -1,0 +1,41 @@
+import { window } from 'vscode';
+import UserOrWorkspaceConfiguration from '../UserOrWorkspaceConfiguration';
+import askUserToAnswerYesOrNo from './AskUserToAnswerYesOrNo';
+
+/**
+ * Shows the user the dialog to choose what configuration to save the parameter in
+ * @return Either the choice of the user or undefined if the user dismissed the dialog
+ */
+export default async function askUserWhatConfigurationToSaveParameterIn(): Promise<UserOrWorkspaceConfiguration | undefined> {
+    const userConfigurationChoice = 'User configuration';
+    const workspaceConfigurationChoice = 'Workspace configuration';
+    while (true) {
+        const choice = await window.showInformationMessage(
+            'What configuration do you want to save the parameter in?',
+            { modal: true },
+            userConfigurationChoice,
+            workspaceConfigurationChoice
+        );
+        switch (choice) {
+            case userConfigurationChoice:
+                return UserOrWorkspaceConfiguration.User;
+            case workspaceConfigurationChoice:
+                return UserOrWorkspaceConfiguration.Workspace;
+            default:
+                // Ask the user if the dialog has been dismissed intentionally and that the
+                // parameter shouldn't be saved. If the user doesn't confirm it, then we continue asking
+                if (await askUserToConfirmCancellation()) {
+                    return undefined;
+                }
+                break;
+        }
+    }
+}
+
+/**
+ * Asks the user if the dialog has been dismissed intentionally
+ * @return The flag indicating if the dialog has been dismissed intentionally
+ */
+async function askUserToConfirmCancellation(): Promise<boolean> {
+    return await askUserToAnswerYesOrNo('The dialog has been dismissed. Do you want to cancel setting the configuration parameter?');
+}

--- a/src/UserOrWorkspaceConfiguration.ts
+++ b/src/UserOrWorkspaceConfiguration.ts
@@ -1,0 +1,19 @@
+/**
+ * The enumeration contains possible configurations supported by Visual Studio Code
+ */
+enum UserOrWorkspaceConfiguration {
+    /**
+     * It's also known as Global Settings, Installation-wide Settings. Properties stored in the
+     * configuration have low precedence, but they are taken into account when the workspace
+     * configuration doesn't define the corresponding properties
+     */
+    User,
+    /**
+     * The configuration for the current workspace
+     */
+    Workspace
+}
+
+// That's the only way to make an enum exported by default.
+// See https://github.com/Microsoft/TypeScript/issues/3792
+export default UserOrWorkspaceConfiguration;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -241,8 +241,7 @@ class RlsMode {
                 async () => {
                     if (this._rustup) {
                         return await this._rustup.installRls();
-                    }
-                    else {
+                    } else {
                         return false;
                     }
                 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -238,7 +238,14 @@ class RlsMode {
             }
             const rlsInstalled = await installComponent(
                 'RLS',
-                async () => { return this._rustup && await this._rustup.installRls(); }
+                async () => {
+                    if (this._rustup) {
+                        return await this._rustup.installRls();
+                    }
+                    else {
+                        return false;
+                    }
+                }
             );
             if (rlsInstalled) {
                 logger.debug('RLS has been installed');
@@ -263,7 +270,13 @@ class RlsMode {
             }
             const rustAnalysisInstalled = await installComponent(
                 'rust-analysis',
-                async () => { return this._rustup && await this._rustup.installRustAnalysis(); }
+                async () => {
+                    if (this._rustup) {
+                        return await this._rustup.installRustAnalysis();
+                    } else {
+                        return false;
+                    }
+                }
             );
             if (rustAnalysisInstalled) {
                 logger.debug('rust-analysis has been installed');


### PR DESCRIPTION
Hello @raggi,
The pull request adds support of asking the user what configuration to save some configuration parameter in.

**Context**:
When the user requested executing a Cargo command which should have been executed in the integrated terminal which kind was unknown

**Before the pull request**:
The extension asked the user to choose what kind of integrated terminal was used and then the choice was saved to the user (global) configuration.

**After the pull request**:
The extension will ask the user to choose what kind of integrated terminal will be used and then what configuration the choice should be saved in.

**Motivation**:
It makes easier to use WSL in one workspace, but another terminal in other.